### PR TITLE
Fix view client/product in second panel

### DIFF
--- a/src/main/java/seedu/address/ui/ViewMoreClient.java
+++ b/src/main/java/seedu/address/ui/ViewMoreClient.java
@@ -37,10 +37,12 @@ public class ViewMoreClient extends UiPart<Region> implements SecondPanel {
         id.setText("ID: " + client.getId().toString());
         name.setText("Name: " + client.getName().toString());
         phoneNumber.setText("Phone Number: " + client.getPhoneNumber().toString());
-        if (client.getEmail() != null)
-        email.setText("Email: " + client.getEmail().toString());
-        if (client.getAddress() != null)
-        address.setText("Address: " + client.getAddress().toString());
+        if (client.getEmail() != null) {
+            email.setText("Email: " + client.getEmail().toString());
+        }
+        if (client.getAddress() != null) {
+            address.setText("Address: " + client.getAddress().toString());
+        }
     }
 
 

--- a/src/main/java/seedu/address/ui/ViewMoreClient.java
+++ b/src/main/java/seedu/address/ui/ViewMoreClient.java
@@ -37,7 +37,9 @@ public class ViewMoreClient extends UiPart<Region> implements SecondPanel {
         id.setText("ID: " + client.getId().toString());
         name.setText("Name: " + client.getName().toString());
         phoneNumber.setText("Phone Number: " + client.getPhoneNumber().toString());
+        if (client.getEmail() != null)
         email.setText("Email: " + client.getEmail().toString());
+        if (client.getAddress() != null)
         address.setText("Address: " + client.getAddress().toString());
     }
 

--- a/src/main/java/seedu/address/ui/ViewMoreProduct.java
+++ b/src/main/java/seedu/address/ui/ViewMoreProduct.java
@@ -34,6 +34,7 @@ public class ViewMoreProduct extends UiPart<Region> implements SecondPanel {
         id.setText("ID: " + product.getId().toString());
         name.setText("Name: " + product.getName().toString());
         unitPrice.setText("Unit Price: " + product.getUnitPrice().toString());
+        if (product.getQuantity() != null)
         quantity.setText("Quantity: " + product.getQuantity().toString());
     }
 

--- a/src/main/java/seedu/address/ui/ViewMoreProduct.java
+++ b/src/main/java/seedu/address/ui/ViewMoreProduct.java
@@ -34,8 +34,9 @@ public class ViewMoreProduct extends UiPart<Region> implements SecondPanel {
         id.setText("ID: " + product.getId().toString());
         name.setText("Name: " + product.getName().toString());
         unitPrice.setText("Unit Price: " + product.getUnitPrice().toString());
-        if (product.getQuantity() != null)
-        quantity.setText("Quantity: " + product.getQuantity().toString());
+        if (product.getQuantity() != null) {
+            quantity.setText("Quantity: " + product.getQuantity().toString());
+        }
     }
 
 

--- a/src/main/resources/view/ViewMoreClient.fxml
+++ b/src/main/resources/view/ViewMoreClient.fxml
@@ -8,9 +8,9 @@
     <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
     </padding>
-    <Label fx:id="id" styleClass="cell_small_label" text="\$unitPrice" />
-    <Label fx:id="name" styleClass="cell_small_label" text="\$unitPrice" />
-    <Label fx:id="phoneNumber" styleClass="cell_small_label" text="\$unitPrice" />
-    <Label fx:id="email" styleClass="cell_small_label" text="\$unitPrice" />
-    <Label fx:id="address" styleClass="cell_small_label" text="\$unitPrice" />
+    <Label fx:id="id" styleClass="cell_small_label" text="No ID provided!" />
+    <Label fx:id="name" styleClass="cell_small_label" text="No name provided!" />
+    <Label fx:id="phoneNumber" styleClass="cell_small_label" text="No phone number provided!" />
+    <Label fx:id="email" styleClass="cell_small_label" text="No email provided!" />
+    <Label fx:id="address" styleClass="cell_small_label" text="No address provided!" />
 </VBox>

--- a/src/main/resources/view/ViewMoreProduct.fxml
+++ b/src/main/resources/view/ViewMoreProduct.fxml
@@ -8,8 +8,8 @@
     <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
     </padding>
-    <Label fx:id="id" styleClass="cell_small_label" text="\$unitPrice" />
-    <Label fx:id="name" styleClass="cell_small_label" text="\$unitPrice" />
-    <Label fx:id="unitPrice" styleClass="cell_small_label" text="\$unitPrice" />
-    <Label fx:id="quantity" styleClass="cell_small_label" text="\$unitPrice" />
+    <Label fx:id="id" styleClass="cell_small_label" text="No ID provided" />
+    <Label fx:id="name" styleClass="cell_small_label" text="No name provided" />
+    <Label fx:id="unitPrice" styleClass="cell_small_label" text="No unit price provided!" />
+    <Label fx:id="quantity" styleClass="cell_small_label" text="No quantity provided!" />
 </VBox>


### PR DESCRIPTION
Previously, null pointer exception was thrown for optional fields for client and product. Now, a placeholder message informs the user that those fields were not provided